### PR TITLE
Update tensor loading in S3 interactions to specify map_location as "cpu"

### DIFF
--- a/utils/s3_interactions.py
+++ b/utils/s3_interactions.py
@@ -673,7 +673,7 @@ def download_activation(path: str) -> torch.Tensor:
         # For local storage, read the file directly
         with open(path, "rb") as f:
             buffer = io.BytesIO(f.read())
-        tensor = torch.load(buffer, weights_only=False)
+        tensor = torch.load(buffer, map_location="cpu", weights_only=False)
         assert isinstance(
             tensor, torch.Tensor
         ), f"Downloaded tensor is not a torch.Tensor: {type(tensor)}, path: {path}"
@@ -685,7 +685,7 @@ def download_activation(path: str) -> torch.Tensor:
     response = s3_client.get_object(Bucket=bucket, Key=path)
     buffer = io.BytesIO(response["Body"].read())
 
-    tensor = torch.load(buffer, weights_only=False)
+    tensor = torch.load(buffer, map_location="cpu", weights_only=False)
     assert isinstance(tensor, torch.Tensor), f"Downloaded tensor is not a torch.Tensor: {type(tensor)}, path: {path}"
     check_for_nans(tensor, f"activation downloaded from {path}")
     return tensor
@@ -740,7 +740,7 @@ def download_optimizer_state(path: str) -> dict[str, Any]:
     bucket, path = normalize_s3_path(path)
     response = s3_client.get_object(Bucket=bucket, Key=path)
     buffer = io.BytesIO(response["Body"].read())
-    return torch.load(buffer, weights_only=False)
+    return torch.load(buffer, map_location="cpu", weights_only=False)
 
 
 def list_all_files(prefix: str = "") -> list[str]:


### PR DESCRIPTION
Fixes:
`miner.miner:step:413 - ❌ Error in step: Attempting to deserialize object on CUDA device 5 but torch.cuda.device_count() is 1. Please use torch.load with map_location to map your storages to an existing device.`

Could be done other ways too..

This lets PyTorch remap any saved device (e.g. cuda:5) to the CPU, avoiding the device-mismatch error. The tensors are moved to the correct device later in the miner workflow with .to(settings.DEVICE), so normal GPU execution is unaffected.