### PR TITLE
Updating Iota version to v0.3.21-46abc219

### DIFF
--- a/shared/common/src/common/settings.py
+++ b/shared/common/src/common/settings.py
@@ -17,7 +17,7 @@ LOG_FILE_ENABLED = os.getenv("LOG_FILE_ENABLED") == "True"
 TEST_MODE = os.getenv("TEST_MODE") == "True"
 
 # Bittensor settings
-__SPEC_VERSION__ = 10_003
+__SPEC_VERSION__ = 10_004
 __VALIDATOR_SPEC_VERSION__ = 4065
 BITTENSOR = os.getenv("BITTENSOR") == "True"
 MAX_NUM_PARTS = int(os.getenv("MAX_NUM_PARTS", 10000))

--- a/shared/common/src/common/utils/formulas.py
+++ b/shared/common/src/common/utils/formulas.py
@@ -2,9 +2,9 @@ import math
 from common import settings as common_settings
 
 
-def get_n_partitions(n_miners: int) -> int:
+def calculate_n_partitions(n_miners: int) -> int:
     return int(max(1, n_miners * (n_miners - 1) / 2))
 
 
-def get_num_parts(data: bytes) -> int:
+def calculate_num_parts(data: bytes) -> int:
     return int(math.ceil(len(data) / common_settings.MAX_PART_SIZE))

--- a/shared/subnet/src/subnet/utils/s3_torch.py
+++ b/shared/subnet/src/subnet/utils/s3_torch.py
@@ -10,8 +10,8 @@ from subnet.utils.vector_utils import check_for_nans_and_infs
 from asyncio.exceptions import TimeoutError
 
 
-async def download_activation(path: str, dtype: torch.dtype = torch.bfloat16, device: str = "cuda") -> torch.Tensor:
-    """Download an activation from S3 storage."""
+async def download_tensor(path: str, dtype: torch.dtype = torch.bfloat16, device: str = "cuda") -> torch.Tensor:
+    """Download bytes and cast into a tensor from S3 storage."""
     try:
         # Download from S3
         timeout = aiohttp.ClientTimeout(total=300)  # 5 minute timeout
@@ -26,19 +26,21 @@ async def download_activation(path: str, dtype: torch.dtype = torch.bfloat16, de
             loaded_tensor, torch.Tensor
         ), f"Downloaded tensor is not a torch.Tensor: {type(loaded_tensor)}, path: {path}"
 
-        check_for_nans_and_infs(loaded_tensor, f"activation downloaded from {path}", exception_type=NanInfWarning)
+        check_for_nans_and_infs(loaded_tensor, f"tensor downloaded from {path}", exception_type=NanInfWarning)
 
         return loaded_tensor
+
     except aiohttp.ClientResponseError as e:
         if e.status >= 500:
             logger.warning(
-                f"Server error (HTTP {e.status}) downloading activation from R2: {e}. This is likely a temporary R2 issue."
+                f"Server error (HTTP {e.status}) downloading tensor from R2: {e}. This is likely a temporary R2 issue."
             )
         else:
-            logger.error(f"HTTP error downloading activation: {e}")
+            logger.error(f"HTTP error downloading tensor: {e}")
         raise
+
     except Exception as e:
-        logger.error(f"Error downloading activation: {e}")
+        logger.error(f"Error downloading tensor: {e}")
         raise
 
 

--- a/src/miner/src/miner/new_miner.py
+++ b/src/miner/src/miner/new_miner.py
@@ -42,7 +42,7 @@ from subnet.base.base_neuron import BaseNeuron
 from subnet.miner_api_client import MinerAPIClient
 from subnet.model.utils import compute_loss
 from subnet.test_client import TestAPIClient
-from subnet.utils.s3_torch import download_activation
+from subnet.utils.s3_torch import download_tensor
 from subnet.utils.vector_utils import check_for_nans_and_infs, flatten_optimizer_state
 
 from miner import settings as miner_settings
@@ -272,7 +272,7 @@ class Miner(BaseNeuron, HealthServerMixin):
             input_activations = await self.download_sample(download_url=activation.presigned_download_url)
         else:
             # Download activation from S3
-            input_activations = await download_activation(
+            input_activations = await download_tensor(
                 path=activation.presigned_download_url, device=miner_settings.DEVICE
             )
             if not common_settings.MOCK:
@@ -403,7 +403,7 @@ class Miner(BaseNeuron, HealthServerMixin):
         if self.state_manager.layer != common_settings.N_LAYERS - 1 and common_settings.N_LAYERS > 1:
             # For backward pass, we need to get activations that we have cached forward activations for
             # So we still need to list first, then filter, then randomly select
-            activation_grads: torch.Tensor = await download_activation(
+            activation_grads: torch.Tensor = await download_tensor(
                 path=activation.presigned_download_url, device=miner_settings.DEVICE
             )
             if not common_settings.MOCK:

--- a/src/miner/src/miner/utils/utils.py
+++ b/src/miner/src/miner/utils/utils.py
@@ -2,7 +2,7 @@ import json
 from typing import Literal, Optional
 
 from common.utils.cache import async_lru
-from common.utils.formulas import get_num_parts
+from common.utils.formulas import calculate_num_parts
 import torch
 from bittensor_wallet import Keypair
 from common import settings as common_settings
@@ -111,7 +111,7 @@ async def upload_file(
     """
     # TODO: We may want to set this to a more optimal value, for now we just make each part 10MB
     try:
-        num_parts = get_num_parts(data=data)
+        num_parts = calculate_num_parts(data=data)
         if num_parts > common_settings.MAX_NUM_PARTS:
             raise ValueError(
                 f"Number of parts must be less than {common_settings.MAX_NUM_PARTS}. Your file with {len(data)} bytes doesn't fit within {common_settings.MAX_NUM_PARTS} part of 10MB each"

--- a/src/validator/src/validator/validator.py
+++ b/src/validator/src/validator/validator.py
@@ -15,7 +15,7 @@ from loguru import logger
 from subnet.base.base_neuron import BaseNeuron
 from subnet.test_client import TestAPIClient
 from subnet.utils.bt_utils import get_subtensor
-from subnet.utils.s3_torch import download_activation
+from subnet.utils.s3_torch import download_tensor
 from subnet.validator_api_client import ValidatorAPIClient
 
 from validator import settings as validator_settings
@@ -113,10 +113,10 @@ class Validator(BaseNeuron, HealthServerMixin, BaseValidator):
         First checks magnitude ratio as a gatekeeper, then cosine similarity if magnitude check passes.
         """
 
-        validator_activations: torch.Tensor = await download_activation(
+        validator_activations: torch.Tensor = await download_tensor(
             path=validator_activation_path, device=validator_settings.DEVICE
         )
-        miner_activations: torch.Tensor = await download_activation(
+        miner_activations: torch.Tensor = await download_tensor(
             path=miner_activation_path, device=validator_settings.DEVICE
         )
 


### PR DESCRIPTION
This moves the result of the merge_partitions endpoint to the scheduler for pre-population. This is because all miners were calling this at the same time, but we know that we can do this before they call it. This will reduce the load on the orch, as well as speed up training significantly. (Not included here) 

Other bug fixes are included here