### PR TITLE
Bittensor Upgrade + Fix Weight Uploading

### DIFF
--- a/shared/common/src/common/models/error_models.py
+++ b/shared/common/src/common/models/error_models.py
@@ -18,8 +18,8 @@ class LayerStateError(BaseModel):
         return self
 
 
-class MinerNotRegisteredError(BaseModel):
-    message: str = "Miner not registered"
+class EntityNotRegisteredError(BaseModel):
+    message: str = "Entity not registered"
     name: Optional[str] = None
 
 

--- a/shared/common/src/common/settings.py
+++ b/shared/common/src/common/settings.py
@@ -16,7 +16,7 @@ LOG_FILE_ENABLED = os.getenv("LOG_FILE_ENABLED") == "True"
 TEST_MODE = os.getenv("TEST_MODE") == "True"
 
 # Bittensor settings
-__SPEC_VERSION__ = 10_032
+__SPEC_VERSION__ = 10_040
 __VALIDATOR_SPEC_VERSION__ = 4065
 BITTENSOR = os.getenv("BITTENSOR") == "True"
 MAX_NUM_PARTS = int(os.getenv("MAX_NUM_PARTS", 10000))

--- a/shared/subnet/pyproject.toml
+++ b/shared/subnet/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "common",
-    "bittensor==9.3.0",
+    "bittensor==9.9.0",
     "bittensor-cli>=9.4.0",
     "tenacity>=9.1.2",
     "torch>=2.6.0",

--- a/shared/subnet/src/subnet/miner_api_client.py
+++ b/shared/subnet/src/subnet/miner_api_client.py
@@ -13,7 +13,7 @@ from common.models.api_models import (
     SyncActivationAssignmentsRequest,
     WeightUpdate,
 )
-from common.models.error_models import BaseErrorModel, LayerStateError, MinerNotRegisteredError, SpecVersionError
+from common.models.error_models import BaseErrorModel, LayerStateError, EntityNotRegisteredError, SpecVersionError
 from common.utils.exceptions import LayerStateException, MinerNotRegisteredException, SpecVersionException
 from common.utils.partitions import MinerPartition
 from common.utils.s3_utils import upload_parts
@@ -235,7 +235,7 @@ class MinerAPIClient:
                 raise LayerStateException(
                     f"Miner is moving state from {error_dict.expected_status} to {error_dict.actual_status}"
                 )
-            if error_name == MinerNotRegisteredError.__name__:
+            if error_name == EntityNotRegisteredError.__name__:
                 logger.error(f"Miner not registered error: {response['error_dict']}")
                 raise MinerNotRegisteredException("Miner not registered")
             if error_name == SpecVersionError.__name__:

--- a/src/miner/src/miner/state_manager.py
+++ b/src/miner/src/miner/state_manager.py
@@ -81,7 +81,7 @@ class StateManager(BaseModel):
         for activation_id in activations_to_remove:
             self.remove_from_cache(activation_id)
 
-    def increment_backward_count(self):
+    def increment_backward_count(self) -> bool:
         """Increment the backward pass counter and return True if optimization step is needed."""
         self.backwards_since_last_optim += 1
         return self.backwards_since_last_optim >= common_settings.MINI_BATCH_ACCUMULATION_COUNT


### PR DESCRIPTION
1. Increases the system to `bittensor=9.9`
2. Removes old gradient checks that prevent miners from uploading weights if they're unlucky
3. Various backend changes (not shown)