### PR TITLE
feat: add Docker support for miner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.venv
+__pycache__
+*.pyc
+.env
+.DS_Store
+logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim-bookworm
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy the application
+COPY . .
+
+# Install dependencies
+RUN uv sync --frozen
+
+# Set environment variables
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/src:$PYTHONPATH"
+
+# Entrypoint
+CMD ["uv", "run", "--package", "miner", "src/miner/main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  miner:
+    build: .
+    env_file:
+      - .env
+    volumes:
+      - ./logs:/app/logs
+    restart: unless-stopped


### PR DESCRIPTION
## Description
This PR addresses issue #122 by adding Docker support to the miner. It introduces a [Dockerfile](cci:7://file:///c:/Users/user/Desktop/pull%20request/Dockerfile:0:0-0:0), [.dockerignore](cci:7://file:///c:/Users/user/Desktop/pull%20request/.dockerignore:0:0-0:0), and [docker-compose.yml](cci:7://file:///c:/Users/user/Desktop/pull%20request/docker-compose.yml:0:0-0:0) to facilitate easy deployment and execution of the miner in a containerized environment.

## Changes
- **Dockerfile**: Created a Dockerfile based on `python:3.12-slim-bookworm` that uses `uv` for dependency management, consistent with the project's setup scripts.
- **.dockerignore**: Added to exclude unnecessary files (like `.venv`, `__pycache__`, `.git`) from the build context.
- **docker-compose.yml**: Added for convenient orchestration, allowing users to start the miner with a simple `docker-compose up`.

## How to Test
1.  Clone the branch.
2.  Ensure your [.env](cci:7://file:///c:/Users/user/Desktop/pull%20request/src/miner/miner-example.env:0:0-0:0) file is populated with the necessary variables (or use the provided `miner-example.env`).
3.  Run:
    ```bash
    docker-compose up --build
    ```
4.  Verify that the miner starts successfully and logs output.

## Related Issue
Fixes #122